### PR TITLE
Change before transformers to be after

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -3,7 +3,7 @@ name: Commit CI
 on:
   push:
     branches:
-      - '*'
+      - '**/*'
       - '!main'
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -10,4 +10,6 @@ This server is meant to be a way to serve typescript source files directly to a 
 
 Optionally, use one or multiple `-e` flags to specify a regex to not tranform to esm.
 
-**Warning** Do not use this to serve a production website. Use this for local development or running tests only.
+# Warning
+
+**Do not use this to serve a production website. Use this for local development or running tests only.**

--- a/fixtures/static/main-es.ts
+++ b/fixtures/static/main-es.ts
@@ -8,9 +8,13 @@
 /* eslint-disable no-console */
 
 import chunk from 'lodash-es/chunk';
+import unistore, { Action } from 'unistore';
 import { v } from './main-import';
 
 export const chunks = chunk(['a', 'b', 'c', 'd'], 2);
 
 console.log(chunks);
 console.log(v);
+console.log(unistore);
+const a: Action<{}> | undefined = undefined;
+console.log(a);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@logicallyabstract/simple-dev-server",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7315,6 +7315,12 @@
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
       }
+    },
+    "unistore": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/unistore/-/unistore-3.5.2.tgz",
+      "integrity": "sha512-2Aa4eX0Ua1umyiI3Eai6Li+wXYOHgaDBGOPB3Hvw7PAVuD30TAyh5kS4yNKb2fLDbQgizvPhKQRcYnOdfsm4VQ==",
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logicallyabstract/simple-dev-server",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Run a dev server using koa with TS and node resolve transforms",
   "main": "dist/server.js",
   "bin": {
@@ -68,7 +68,8 @@
     "prettier": "^2.0.5",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.1.0",
-    "ts-node": "^8.10.2"
+    "ts-node": "^8.10.2",
+    "unistore": "^3.5.2"
   },
   "files": [
     "dist"

--- a/src/transpile.test.ts
+++ b/src/transpile.test.ts
@@ -26,4 +26,13 @@ describe('transpile', () => {
     expect(result).not.toContain('require');
     expect(result).toContain('import');
   });
+
+  it('should remove type only imports', () => {
+    const m = `
+      import unistore, { Action } from 'unistore';
+      const a: Action<{}> | undefined = undefined;
+      console.log(a);`;
+    const result = transpile(m, '/');
+    expect(result).not.toContain('Action');
+  });
 });

--- a/src/transpile.ts
+++ b/src/transpile.ts
@@ -145,7 +145,7 @@ const rewriteProcessEnv = (input: string): string => {
 };
 
 export const transpile = (input: string, path: string) => {
-  const beforeTransformers = [
+  const afterTransformers = [
     cjsToEsmTransformerFactory(),
     rewriteNodeResolve(path),
     rewriteLocalPathExts(path),
@@ -166,7 +166,7 @@ export const transpile = (input: string, path: string) => {
       experimentalDecorators: true,
     },
     transformers: {
-      before: beforeTransformers,
+      after: afterTransformers,
     },
   });
 


### PR DESCRIPTION
This fixes #17 by letting TS strip type-only imports before the
custom transformers are run.

Bump version to 0.5.1